### PR TITLE
docs(meta): removed visible HTML from Will Produce

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,9 @@ themes:
 
       <p>Will Produce:</p>
 
-      <pre>&lt;img src="<img class="demo" src="square/code/403.svg"/>"/&gt;&#10;&#10;&lt;img src="<img class="demo" src="flat/full/502.png"/>"/&gt;</pre>
+      <pre><img class="demo" src="square/code/403.svg"/>
+
+<img class="demo" src="flat/full/502.png"/></pre>
 
       <br/>
 


### PR DESCRIPTION
In reading the docs, I felt that removing the visible `img` tag HTML from the Example, Will Produce section made more sense.

The odd indentation comes at the expense of not going down a rabbit hole of creating a new CSS class to inherit/recreate the properties of `pre` from remotely hosted `hack.css`. I tested on local jekyll and it renders in Chrome correctly for me.